### PR TITLE
Change UART1_BASE address

### DIFF
--- a/bios/platform_config.h
+++ b/bios/platform_config.h
@@ -53,7 +53,7 @@
 #define DRAM_START		0x40000000
 
 #define UART0_BASE		0x09000000
-#define UART1_BASE		0x09010000
+#define UART1_BASE		0x09040000
 
 
 #else


### PR DESCRIPTION
This is required to move OP-TEE to upstream QEMU.

Signed-off-by: Victor Chong victor.chong@linaro.org
Suggested-by: Peter Maydell peter.maydell@linaro.org
Tested-by: Victor Chong victor.chong@linaro.org
