### PR TITLE
Allow boot from device

### DIFF
--- a/bios/bios.mk
+++ b/bios/bios.mk
@@ -2,6 +2,7 @@ include bios/conf.mk
 
 cppflags += -DPLATFORM_FLAVOR=PLATFORM_FLAVOR_ID_$(PLATFORM_FLAVOR)
 cppflags += -Iinclude
+cppflags += -DCOMMAND_LINE="\"$(BIOS_COMMAND_LINE)\""
 
 #
 # Do libraries

--- a/bios/conf.mk
+++ b/bios/conf.mk
@@ -4,6 +4,11 @@ include mk/gcc.mk
 
 PLATFORM_FLAVOR ?= vexpress
 
+BIOS_COMMAND_LINE = console=ttyAMA0,115200 \
+		    earlyprintk=serial,ttyAMA0,115200 \
+		    dynamic_debug.verbose=1 \
+		    $(BIOS_ROOT_DEVICE)
+
 cpuarch = cortex-a15
 cflags	 = -mcpu=$(cpuarch) -mthumb
 cflags	+= -mthumb-interwork -mlong-calls

--- a/bios/link.mk
+++ b/bios/link.mk
@@ -84,12 +84,19 @@ endif
 
 ifndef BIOS_NSEC_ROOTFS
 $(error BIOS_NSEC_ROOTFS not defined!)
-endif
+else ifeq ($(BIOS_NSEC_ROOTFS),/dev/null)
+$(out-dir)nsec_rootfs.bin: FORCE
+	@echo '  MAKE    $@'
+	@mkdir -p $(dir $@)
+	@rm -f $@
+	$(q) echo 'Empty' > $@
+else
 $(out-dir)nsec_rootfs.bin: $(BIOS_NSEC_ROOTFS) FORCE
 	@echo '  LN      $@'
 	@mkdir -p $(dir $@)
 	@rm -f $@
 	$(q)ln -s $(abspath $<) $@
+endif
 
 $(out-dir)nsec_rootfs.o: $(out-dir)nsec_rootfs.bin FORCE
 	@echo '  OBJCOPY $@'

--- a/bios/main.c
+++ b/bios/main.c
@@ -621,8 +621,7 @@ static void call_kernel(uint32_t entry, uint32_t dtb,
 {
 	kernel_ep_func ep = (kernel_ep_func)entry;
 	void *fdt = (void *)dtb;
-	const char cmdline[] =
-"console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200 dynamic_debug.verbose=1";
+	const char cmdline[] = COMMAND_LINE;
 	int r;
 	const uint32_t a0 = 0;
 	/*MACH_VEXPRESS see linux/arch/arm/tools/mach-types*/


### PR DESCRIPTION
These two patches allow the bios to be used with a "real" root fs instead of an initrd.  A filesystem image can easily be given to qemu, and this allows state to persist across reboots.
