### PR TITLE
Pass Device Tree address to OP-TEE

### DIFF
--- a/bios/entry.S
+++ b/bios/entry.S
@@ -83,11 +83,11 @@ new_loc:
 	ldr	ip, =main_stack_top;
 	ldr	sp, [ip]
 
-	push	{r0, r1}
+	push	{r0, r1, r2}
 	mov	r0, sp
 	ldr	ip, =main_init_sec
 	blx	ip
-	pop	{r0, r1}
+	pop	{r0, r1, r2}
 	mov	ip, r0	/* entry address */
 	mov	r0, r1	/* argument (address of pagable part if != 0) */
 	blx	ip

--- a/bios/main.c
+++ b/bios/main.c
@@ -529,6 +529,7 @@ struct optee_header {
 struct sec_entry_arg {
 	uint32_t entry;
 	uint32_t paged_part;
+	uint32_t fdt;
 };
 /* called from assembly only */
 void main_init_sec(struct sec_entry_arg *arg);
@@ -585,6 +586,7 @@ void main_init_sec(struct sec_entry_arg *arg)
 	 * we load them.
 	 */
 	copy_ns_images();
+	arg->fdt = dtb_addr;
 
 	msg("Initializing secure world\n");
 }
@@ -627,6 +629,8 @@ static void call_kernel(uint32_t entry, uint32_t dtb,
 	/*MACH_VEXPRESS see linux/arch/arm/tools/mach-types*/
 	const uint32_t a1 = 2272;
 
+	r = fdt_open_into(fdt, fdt, DTB_MAX_SIZE);
+	CHECK(r < 0);
 	setprop_cell(fdt, "/chosen", "linux,initrd-start", initrd);
 	setprop_cell(fdt, "/chosen", "linux,initrd-end", initrd_end);
 	setprop_string(fdt, "/chosen", "bootargs", cmdline);


### PR DESCRIPTION
Passes Device Tree address to OP-TEE in r2.

Signed-off-by: Jens Wiklander jens.wiklander@linaro.org
