### PR TITLE
Remove -mno-apcs-float

### DIFF
--- a/bios/conf.mk
+++ b/bios/conf.mk
@@ -12,7 +12,7 @@ BIOS_COMMAND_LINE = console=ttyAMA0,115200 \
 cpuarch = cortex-a15
 cflags	 = -mcpu=$(cpuarch) -mthumb
 cflags	+= -mthumb-interwork -mlong-calls
-cflags += -fno-short-enums -mno-apcs-float -fno-common
+cflags += -fno-short-enums -fno-common
 cflags += -mno-unaligned-access
 aflags	 = -mcpu=$(cpuarch)
 


### PR DESCRIPTION
This option is not supported anymore by GCC 7, and was not needed since
at least GCC 4.8.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>