### PR TITLE
Align qemu_virt smp entry mailbox with arm-tf mailbox

### DIFF
--- a/bios/entry.S
+++ b/bios/entry.S
@@ -147,16 +147,25 @@ LOCAL_FUNC zero_mem , :
 	b	zero_mem
 END_FUNC zero_mem
 
+/*
+ * struct mailbox {
+ *	uint32_t entry_addr;		LSB stores the 32bit entry address.
+ *	uint32_t reserved;
+ *	uint64_t pen[NB_CPU];		Core released if 32b LSB pen[core]!=0.
+ * }
+ */
 LOCAL_FUNC secondary_hold , :
-	mov_imm	r1, SECURE_RAM_START
-	add	r0, r1, r0, LSL #2
+	mov_imm	r2, SECURE_RAM_START
+	add	r0, r2, r0, LSL #3
 	mov	r1, #0
-	str	r1, [r0]
+	str	r1, [r0, #8]
 1:
-	ldr	r1, [r0]
+	ldr	r1, [r0, #8]
 	cmp	r1, #0
 	wfeeq
 	beq	1b
+	dsb
+	ldr	r1, [r2]
 	bx	r1
 END_FUNC secondary_hold
 

--- a/bios/main.c
+++ b/bios/main.c
@@ -189,6 +189,8 @@ struct sec_entry_arg {
 	uint32_t fdt;
 };
 
+#define PAGESTORE_OFFSET	0x00400000
+
 static void copy_secure_images(struct sec_entry_arg *arg)
 {
 	long r;
@@ -217,14 +219,16 @@ static void copy_secure_images(struct sec_entry_arg *arg)
 		CHECK(hdr.images[1].image_id != OPTEE_IMAGE_ID_PAGED);
 		if (hdr.images[1].load_addr_lo == 0xffffffff &&
 		    hdr.images[1].load_addr_hi == 0xffffffff) {
-			dst = (size_t)TZ_RES_MEM_START + TZ_RES_MEM_SIZE -
-				hdr.images[1].size;
+			dst = (size_t)TZ_RES_MEM_START + PAGESTORE_OFFSET;
 		} else {
 			CHECK(hdr.images[1].load_addr_hi != 0);
 			dst = hdr.images[1].load_addr_lo;
 		}
+
 		r = semihosting_download_file("tee-pageable_v2.bin",
-					      TZ_RES_MEM_SIZE, dst);
+					       TZ_RES_MEM_START +
+					       TZ_RES_MEM_SIZE - dst,
+						dst);
 		CHECK(r < 0);
 		arg->paged_part = dst;
 	}


### PR DESCRIPTION
Align qemu_virt smp entry mailbox with arm-tf mailbox
+
Prevent bootload issues when pager + secure data path are enabled.
